### PR TITLE
feat: Add support for LaTeX files in search

### DIFF
--- a/frontend/src/app/add-code-file/page.tsx
+++ b/frontend/src/app/add-code-file/page.tsx
@@ -105,6 +105,7 @@ export default function AddCodeFilePage() {
                   <SelectItem value="c">C</SelectItem>
                   <SelectItem value="cpp">C++</SelectItem>
                   <SelectItem value="csharp">C#</SelectItem>
+                  <SelectItem value="latex">LaTeX</SelectItem>
                   <SelectItem value="other">Other</SelectItem>
                 </SelectContent>
               </Select>

--- a/worker/src/services/repo-service.ts
+++ b/worker/src/services/repo-service.ts
@@ -36,6 +36,9 @@ export function detectLanguage(filePath: string): string {
     ".markdown": "markdown",
     ".rst": "restructuredtext",
     ".adoc": "asciidoc",
+    ".tex": "latex",
+    ".ltx": "latex",
+    ".latex": "latex",
 
     // Stylesheets
     ".css": "css",


### PR DESCRIPTION
Add support for LaTeX files in the language dropdown.

* Add `LaTeX` as an option in the language dropdown in `frontend/src/app/add-code-file/page.tsx`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Krish120003/code-search/pull/1?shareId=10861f79-3dea-4921-a481-9859722f4d8a).