### PR TITLE
fix: search query escaping for special characters

### DIFF
--- a/connector/src/index.ts
+++ b/connector/src/index.ts
@@ -78,12 +78,22 @@ async function deleteDocumentsByQuery(query: string): Promise<void> {
 }
 
 /**
+ * Escape Solr special characters
+ * @param query The query string to escape.
+ */
+function escapeSolrQuery(query: string): string {
+  const specialChars = /([+\-&|!(){}[\]^"~*?:\\\/])/g;
+  return query.replace(specialChars, "\\$1");
+}
+
+/**
  * Performs a search query.
  * @param query The Solr search query (e.g., 'description:test').
  */
 async function searchDocuments(queryString: string): Promise<any> {
   try {
-    const query = client.query().q(queryString); // Basic query
+    const escapedQuery = escapeSolrQuery(queryString);
+    const query = client.query().q(escapedQuery); // Basic query
     // Add more query parameters as needed, e.g.:
     // query.start(0).rows(10).fl(['id', 'title']);
 

--- a/frontend/src/server/services/solr.ts
+++ b/frontend/src/server/services/solr.ts
@@ -30,9 +30,8 @@ export async function addFile(file: {
 
 // Escape Solr special characters
 function escapeSolrQuery(query: string): string {
-  // Escape Solr special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
-  // return query.replace(/([+\-&|!(){}[\]^"~*?:\\\/])/g, "\\$1");
-  return query;
+  const specialChars = /([+\-&|!(){}[\]^"~*?:\\\/])/g;
+  return query.replace(specialChars, "\\$1");
 }
 
 // Process content to create highlighted snippets


### PR DESCRIPTION
Update the Solr query escaping to properly handle special characters.

* **frontend/src/server/services/solr.ts**
  - Update the `escapeSolrQuery` function to properly escape special characters in the query string.
* **connector/src/index.ts**
  - Add the `escapeSolrQuery` function to properly escape special characters in the query string.
  - Update the `searchDocuments` function to use the `escapeSolrQuery` function for escaping the query string.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Krish120003/code-search/pull/2?shareId=d78fbef4-b05a-40e3-acd0-26b3bdff9f3b).