### PR TITLE
feat: Add retry count to job object and handle failed tasks

### DIFF
--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -1,4 +1,3 @@
-// Job related types
 export interface Job {
   url: string;
   createdAt: string;
@@ -7,11 +6,11 @@ export interface Job {
   processingEndedAt?: string;
   error?: string;
   processingId?: string;
+  retryCount?: number;
 }
 
 export type JobStatus = "pending" | "processing" | "completed" | "failed";
 
-// Git repo related types
 export interface RepoMetadata {
   url: string;
   owner: string;
@@ -19,7 +18,6 @@ export interface RepoMetadata {
   clonePath: string;
 }
 
-// File related types
 export interface CodeFile {
   id: string;
   repoUrl: string;


### PR DESCRIPTION
Add retry count tracking and failed queue handling to job processing.

* **worker/src/types.ts**
  - Add `retryCount` attribute to `Job` interface to track the number of retries.

* **worker/src/services/redis-client.ts**
  - Add `failedQueueName` and `maxRetryCount` constants.
  - Increment `retryCount` attribute in `markJobAsFailed` function.
  - Check if `retryCount` exceeds `maxRetryCount` in `markJobAsFailed` function.
  - Push job to failed queue if `retryCount` exceeds `maxRetryCount`.
  - Add `pushToFailedQueue` function to handle pushing tasks to the failed queue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Krish120003/code-search/pull/3?shareId=655a0943-152f-4269-85c4-52694c7c83c4).